### PR TITLE
hotfix: tokio-timer may panic when running over 795 days

### DIFF
--- a/tokio-timer/src/delay_queue.rs
+++ b/tokio-timer/src/delay_queue.rs
@@ -161,9 +161,11 @@ pub struct Expired<T> {
     data: T,
 
     /// The expiration time
+    #[allow(unused)]
     deadline: Instant,
 
     /// The key associated with the entry
+    #[allow(unused)]
     key: Key,
 }
 

--- a/tokio-timer/src/error.rs
+++ b/tokio-timer/src/error.rs
@@ -72,7 +72,10 @@ impl error::Error for Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        use std::error::Error;
-        self.description().fmt(fmt)
+        use self::Kind::*;
+        match self.0 {
+            Shutdown => "timer is shutdown".fmt(fmt),
+            AtCapacity => "timer is at capacity and cannot create a new entry".fmt(fmt),
+        }
     }
 }

--- a/tokio-timer/src/error.rs
+++ b/tokio-timer/src/error.rs
@@ -74,8 +74,8 @@ impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         use self::Kind::*;
         match self.0 {
-            Shutdown => "timer is shutdown".fmt(fmt),
-            AtCapacity => "timer is at capacity and cannot create a new entry".fmt(fmt),
+            Shutdown => write!(fmt, "timer is shutdown"),
+            AtCapacity => write!(fmt, "timer is at capacity and cannot create a new entry"),
         }
     }
 }

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -1,7 +1,13 @@
-#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.12")]
+#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.13")]
 #![deny(missing_docs, missing_debug_implementations)]
 
 //! Utilities for tracking time.
+//!
+//! > **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved
+//! > into [`tokio::time`] behind the `time` [feature flag].
+//!
+//! [`tokio::time`]: https://docs.rs/tokio/latest/tokio/time/index.html
+//! [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
 //!
 //! This crate provides a number of utilities for working with periods of time:
 //!

--- a/tokio-timer/src/timeout.rs
+++ b/tokio-timer/src/timeout.rs
@@ -9,7 +9,6 @@ use Delay;
 
 use futures::{Async, Future, Poll, Stream};
 
-use std::error;
 use std::fmt;
 use std::time::{Duration, Instant};
 
@@ -282,18 +281,6 @@ impl<T> Error<T> {
         match self.0 {
             Kind::Timer(err) => Some(err),
             _ => None,
-        }
-    }
-}
-
-impl<T: error::Error> error::Error for Error<T> {
-    fn description(&self) -> &str {
-        use self::Kind::*;
-
-        match self.0 {
-            Inner(ref e) => e.description(),
-            Elapsed => "deadline has elapsed",
-            Timer(ref e) => e.description(),
         }
     }
 }

--- a/tokio-timer/src/timer/atomic_stack.rs
+++ b/tokio-timer/src/timer/atomic_stack.rs
@@ -103,7 +103,7 @@ impl Iterator for AtomicStackEntries {
         let entry = unsafe { Arc::from_raw(self.ptr) };
 
         // Update `self.ptr` to point to the next element of the stack
-        self.ptr = unsafe { (*entry.next_atomic.get()) };
+        self.ptr = unsafe { *entry.next_atomic.get() };
 
         // Unset the queued flag
         let res = entry.queued.fetch_and(false, SeqCst);

--- a/tokio-timer/src/timer/entry.rs
+++ b/tokio-timer/src/timer/entry.rs
@@ -205,7 +205,7 @@ impl Entry {
     /// The current entry state as known by the timer. This is not the value of
     /// `state`, but lets the timer know how to converge its state to `state`.
     pub fn when_internal(&self) -> Option<u64> {
-        unsafe { (*self.when.get()) }
+        unsafe { *self.when.get() }
     }
 
     pub fn set_when_internal(&self, when: Option<u64>) {

--- a/tokio-timer/src/wheel/level.rs
+++ b/tokio-timer/src/wheel/level.rs
@@ -46,7 +46,7 @@ impl<T: Stack> Level<T> {
             () => {
                 T::default()
             };
-        };
+        }
 
         Level {
             level,
@@ -217,7 +217,7 @@ impl<T> fmt::Debug for Level<T> {
 }
 
 fn occupied_bit(slot: usize) -> u64 {
-    (1 << slot)
+    1 << slot
 }
 
 fn slot_range(level: usize) -> u64 {

--- a/tokio-timer/src/wheel/mod.rs
+++ b/tokio-timer/src/wheel/mod.rs
@@ -26,6 +26,9 @@ pub(crate) struct Wheel<T> {
 
     /// Timer wheel.
     ///
+    /// Hotfix: some application may keep running over 2 years, to avoid such application panic,
+    /// the level vector should provide slots for longer duration.
+    ///
     /// Levels:
     ///
     /// * 1 ms slots / 64 ms range
@@ -34,13 +37,15 @@ pub(crate) struct Wheel<T> {
     /// * ~ 4 min slots / ~ 4 hr range
     /// * ~ 4 hr slots / ~ 12 day range
     /// * ~ 12 day slots / ~ 2 yr range
+    /// * ~ 2 yr slots / ~ 139 yr range
     levels: Vec<Level<T>>,
 }
 
 /// Number of levels. Each level has 64 slots. By using 6 levels with 64 slots
 /// each, the timer is able to track time up to 2 years into the future with a
 /// precision of 1 millisecond.
-const NUM_LEVELS: usize = 6;
+/// Hotfix: add one more level to support longer duration.
+const NUM_LEVELS: usize = 7;
 
 /// The maximum duration of a delay
 const MAX_DURATION: u64 = 1 << (6 * NUM_LEVELS);
@@ -273,7 +278,7 @@ mod test {
             );
         }
 
-        for level in 1..5 {
+        for level in 1..6 {
             for pos in level..64 {
                 let a = pos * 64_usize.pow(level as u32);
                 assert_eq!(

--- a/tokio-timer/tests/delay.rs
+++ b/tokio-timer/tests/delay.rs
@@ -335,11 +335,11 @@ fn very_long_delay() {
 
 #[test]
 fn greater_than_max() {
-    const YR_5: u64 = 5 * 365 * 24 * 60 * 60 * 1000;
+    const YR_140: u64 = 140 * 365 * 24 * 60 * 60 * 1000;
 
     mocked(|timer, time| {
         // Create a `Delay` that elapses in the future
-        let mut delay = Delay::new(time.now() + ms(YR_5));
+        let mut delay = Delay::new(time.now() + ms(YR_140));
 
         assert_not_ready!(delay);
 

--- a/tokio-timer/tests/queue.rs
+++ b/tokio-timer/tests/queue.rs
@@ -390,7 +390,7 @@ fn reset_first_expiring_item_to_expire_later() {
         let epoch = time.now();
 
         let foo = queue.insert_at("foo", epoch + ms(200));
-        let bar = queue.insert_at("bar", epoch + ms(250));
+        let _bar = queue.insert_at("bar", epoch + ms(250));
 
         task.enter(|| {
             assert_not_ready!(queue);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

`tokio-timer` may panic when running over 795 days.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This PR fixes the panic by enlarging the length of level vector, and preventing the panic of `tokio-timer` within 139 years.
