### PR TITLE
hotfix: update tokio-timer to v0.2.13

### DIFF
--- a/tokio-timer/CHANGELOG.md
+++ b/tokio-timer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.13 (February 4, 2020)
+
+* Add `tokio 0.2.x` deprecation notice.
+
 # 0.2.12 (November 27, 2019)
 
 ### Added

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -8,11 +8,11 @@ name = "tokio-timer"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.12"
+version = "0.2.13"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio-timer/0.2.12/tokio_timer"
+documentation = "https://docs.rs/tokio-timer/0.2.13/tokio_timer"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 description = """
@@ -22,7 +22,7 @@ Timer facilities for Tokio
 [dependencies]
 futures = "0.1.19"
 tokio-executor = "0.1.1"
-crossbeam-utils = "0.6.0"
+crossbeam-utils = "0.7.0"
 
 # Backs `DelayQueue`
 slab = "0.4.1"

--- a/tokio-timer/README.md
+++ b/tokio-timer/README.md
@@ -2,6 +2,12 @@
 
 Timer facilities for Tokio
 
+> **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved into
+> [`tokio::time`] behind the `time` [feature flag].
+
+[`tokio::time`]: https://docs.rs/tokio/latest/tokio/time/index.html
+[feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
+
 [Documentation](https://docs.rs/tokio-timer/0.2.12/tokio_timer/)
 
 ## Overview


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The forked branch is based on `v0.2.12`, and #1 updated it to `v0.2.13` but the updates for `Cargo.toml`, `README.md`, and `CHANGELOG.md` were missing.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This PR principally updates the version of `crossbeam-utils` and avoids the risk of its downgrade.

